### PR TITLE
Remove Codecov integration from workflows

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,11 +30,7 @@ jobs:
           go-version: 1.23.x
       - name: Run tests
         run: |
-          go test -v -coverprofile coverage.out -covermode atomic ./... 
-      - name: Publish coverage
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          go test -v -coverprofile coverage.out -covermode atomic ./...
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -28,11 +28,7 @@ jobs:
         with:
           go-version: 1.23.x
       - name: Test
-        run: go test -v -coverprofile coverage.out -covermode atomic ./... 
-      - name: Publish coverage
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+        run: go test -v -coverprofile coverage.out -covermode atomic ./...
   publish:
     needs:
       - build


### PR DESCRIPTION
## Summary

This PR removes the Codecov integration steps from GitHub Actions workflows to resolve warnings about the missing `CODECOV_TOKEN` secret.

## Changes Made

### Modified Files
- `.github/workflows/pull-request.yml` - Removed codecov upload step (lines 34-37)
- `.github/workflows/release-dev.yaml` - Removed codecov upload step (lines 32-35)

### What's Removed
- `codecov/codecov-action@v5` step that uploads coverage reports to codecov.io
- Reference to `secrets.CODECOV_TOKEN` that was causing VS Code warnings

### What's Kept
- Coverage report generation (`-coverprofile coverage.out -covermode atomic`)
- All test execution remains unchanged
- Coverage files are still created locally for review

## Rationale

For a private, personal-use repository, uploading coverage reports to codecov.io is unnecessary overhead. The `CODECOV_TOKEN` secret is not configured and was causing warnings in VS Code. 

Coverage reports are still generated during test runs and can be reviewed locally using:
```bash
go test ./... -coverprofile coverage.out
go tool cover -html=coverage.out
```

## Testing

No functional changes to test execution. The workflows will continue to:
- Run all tests with coverage enabled
- Generate coverage reports locally
- Fail the build if tests fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)