### PR TITLE
Migrate goreleaser configuration to v2 syntax

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,28 +1,32 @@
 version: 2
-build:
-  main: ./main.go
-  binary: watchtower
-  goos:
-    - linux
-    - windows
-  goarch:
-    - amd64
-    - 386
-    - arm
-    - arm64
-  ldflags:
-    - -s -w -X github.com/containrrr/watchtower/internal/meta.Version={{.Version}}
+builds:
+  - id: watchtower
+    main: ./main.go
+    binary: watchtower
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - 386
+      - arm
+      - arm64
+    ldflags:
+      - -s -w -X github.com/containrrr/watchtower/internal/meta.Version={{.Version}}
 archives:
-  - 
-    name_template: "{{.ProjectName}}_{{.Os}}_{{.Arch}}"
+  -
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- if eq .Os "darwin" }}macOS
+      {{- else if eq .Os "linux" }}linux
+      {{- else if eq .Os "windows" }}windows
+      {{- else }}{{ .Os }}{{ end }}_
+      {{- if eq .Arch "amd64" }}amd64
+      {{- else if eq .Arch "386" }}386
+      {{- else if eq .Arch "arm" }}armhf
+      {{- else if eq .Arch "arm64" }}arm64v8
+      {{- else }}{{ .Arch }}{{ end }}
     format: tar.gz
-    replacements:
-      arm: armhf
-      arm64: arm64v8
-      amd64: amd64
-      386: 386
-      darwin: macOS
-      linux: linux
     format_overrides:
       - goos: windows
         format: zip
@@ -30,7 +34,8 @@ archives:
       - LICENSE.md
 dockers:
   -
-    use_buildx: true
+    ids:
+      - watchtower
     build_flag_templates: [ "--platform=linux/amd64" ]
     goos: linux
     goarch: amd64
@@ -41,10 +46,9 @@ dockers:
       - todd2982/watchtower:amd64-latest
       - ghcr.io/todd2982/watchtower:amd64-{{ .Version }}
       - ghcr.io/todd2982/watchtower:amd64-latest
-    binaries:
+  -
+    ids:
       - watchtower
-  - 
-    use_buildx: true
     build_flag_templates: [ "--platform=linux/386" ]
     goos: linux
     goarch: 386
@@ -55,10 +59,9 @@ dockers:
       - todd2982/watchtower:i386-latest
       - ghcr.io/todd2982/watchtower:i386-{{ .Version }}
       - ghcr.io/todd2982/watchtower:i386-latest
-    binaries:
+  -
+    ids:
       - watchtower
-  - 
-    use_buildx: true
     build_flag_templates: [ "--platform=linux/arm/v6" ]
     goos: linux
     goarch: arm
@@ -69,10 +72,9 @@ dockers:
       - todd2982/watchtower:armhf-latest
       - ghcr.io/todd2982/watchtower:armhf-{{ .Version }}
       - ghcr.io/todd2982/watchtower:armhf-latest
-    binaries:
+  -
+    ids:
       - watchtower
-  - 
-    use_buildx: true
     build_flag_templates: [ "--platform=linux/arm64/v8" ]
     goos: linux
     goarch: arm64
@@ -83,5 +85,3 @@ dockers:
       - todd2982/watchtower:arm64v8-latest
       - ghcr.io/todd2982/watchtower:arm64v8-{{ .Version }}
       - ghcr.io/todd2982/watchtower:arm64v8-latest
-    binaries:
-      - watchtower


### PR DESCRIPTION
## Summary

This PR migrates `goreleaser.yml` to v2-compatible syntax, implementing **Option 1** from issue #45.

Fixes #45

## Problem

All PR builds were failing with YAML parsing errors when using goreleaser v2.13.1:
```
yaml: unmarshal errors:
  line 2: field build not found in type config.Project
  line 19: field replacements not found in type config.Archive
  line 33: field use_buildx not found in type config.Docker
  line 44: field binaries not found in type config.Docker
  (+ similar errors for other Docker configurations)
```

## Changes Made

### 1. Updated `build` → `builds` (lines 2-15)

**Before:**
```yaml
build:
  main: ./main.go
  binary: watchtower
```

**After:**
```yaml
builds:
  - id: watchtower
    main: ./main.go
    binary: watchtower
```

### 2. Removed `replacements` from archives (lines 16-34)

**Before:**
```yaml
archives:
  - 
    name_template: "{{.ProjectName}}_{{.Os}}_{{.Arch}}"
    replacements:
      arm: armhf
      arm64: arm64v8
      amd64: amd64
      386: 386
```

**After:**
```yaml
archives:
  -
    name_template: >-
      {{ .ProjectName }}_
      {{- if eq .Os "darwin" }}macOS
      {{- else if eq .Os "linux" }}linux
      {{- else if eq .Os "windows" }}windows
      {{- else }}{{ .Os }}{{ end }}_
      {{- if eq .Arch "amd64" }}amd64
      {{- else if eq .Arch "386" }}386
      {{- else if eq .Arch "arm" }}armhf
      {{- else if eq .Arch "arm64" }}arm64v8
      {{- else }}{{ .Arch }}{{ end }}
```

### 3. Updated all Docker configurations (lines 35-88)

**Removed deprecated fields:**
- `use_buildx: true` (always enabled in v2)
- `binaries:` field

**Added required fields:**
- `ids:` referencing the build ID

**Before:**
```yaml
dockers:
  - use_buildx: true
    binaries:
      - watchtower
```

**After:**
```yaml
dockers:
  - ids:
      - watchtower
```

Applied to all 4 Docker configurations (amd64, i386, armhf, arm64v8).

## Testing

This PR should resolve the build failures in the CI pipeline. The Build job should now:
- ✅ Parse goreleaser.yml successfully
- ✅ Build binaries for all platforms (linux, windows) × (amd64, 386, arm, arm64)
- ✅ Create Docker images for all architectures
- ✅ Generate archives with correct naming

## Migration Reference

- [goreleaser v2 Migration Guide](https://goreleaser.com/deprecations/)
- [goreleaser v2 Configuration Reference](https://goreleaser.com/customization/)

## Impact

- **Backward compatible**: No changes to build outputs or artifacts
- **Future-proof**: Uses current goreleaser v2 best practices
- **No breaking changes**: Archive names and Docker images remain the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)