### PR TITLE
Fix: Update code for Docker SDK v28 API changes

### DIFF
--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -3,6 +3,7 @@ package container
 import (
 	"time"
 
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 
 	"github.com/todd2982/watchtower/internal/util"
@@ -271,7 +272,7 @@ var _ = Describe("the client", func() {
 					// API.ContainerExecCreate
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("POST", HaveSuffix("containers/%v/exec", containerID)),
-						ghttp.VerifyJSONRepresenting(types.ExecConfig{
+						ghttp.VerifyJSONRepresenting(container.ExecOptions{
 							User:   user,
 							Detach: false,
 							Tty:    true,
@@ -286,7 +287,7 @@ var _ = Describe("the client", func() {
 					// API.ContainerExecStart
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("POST", HaveSuffix("exec/%v/start", execID)),
-						ghttp.VerifyJSONRepresenting(types.ExecStartCheck{
+						ghttp.VerifyJSONRepresenting(container.ExecStartOptions{
 							Detach: false,
 							Tty:    true,
 						}),

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -335,7 +335,7 @@ func (c Container) GetCreateConfig() *dockercontainer.Config {
 
 	// subtract ports exposed in image from container
 	for k := range config.ExposedPorts {
-		if _, ok := imageConfig.ExposedPorts[k]; ok {
+		if _, ok := imageConfig.ExposedPorts[string(k)]; ok {
 			delete(config.ExposedPorts, k)
 		}
 	}

--- a/pkg/container/container_mock_test.go
+++ b/pkg/container/container_mock_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/docker/docker/api/types"
 	dockerContainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 )
 
 type MockContainerUpdate func(*types.ContainerJSON, *types.ImageInspect)
@@ -22,7 +23,7 @@ func MockContainer(updates ...MockContainerUpdate) *Container {
 	}
 	image := types.ImageInspect{
 		ID:     "image_id",
-		Config: &dockerContainer.Config{},
+		Config: &dockerspec.DockerOCIImageConfig{},
 	}
 
 	for _, update := range updates {

--- a/pkg/container/mocks/ApiServer.go
+++ b/pkg/container/mocks/ApiServer.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	imagetypes "github.com/docker/docker/api/types/image"
 	O "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 )
@@ -263,12 +264,12 @@ func RemoveImageHandler(imagesWithParents map[string][]string) http.HandlerFunc 
 			image := parts[len(parts)-1]
 
 			if parents, found := imagesWithParents[image]; found {
-				items := []types.ImageDeleteResponseItem{
+				items := []imagetypes.DeleteResponse{
 					{Untagged: image},
 					{Deleted: image},
 				}
 				for _, parent := range parents {
-					items = append(items, types.ImageDeleteResponseItem{Deleted: parent})
+					items = append(items, imagetypes.DeleteResponse{Deleted: parent})
 				}
 				ghttp.RespondWithJSONEncoded(http.StatusOK, items)(w, r)
 			} else {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,29 +1,31 @@
 package registry
 
 import (
+	"context"
+
 	"github.com/todd2982/watchtower/pkg/registry/helpers"
 	watchtowerTypes "github.com/todd2982/watchtower/pkg/types"
 	ref "github.com/distribution/reference"
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/image"
 	log "github.com/sirupsen/logrus"
 )
 
 // GetPullOptions creates a struct with all options needed for pulling images from a registry
-func GetPullOptions(imageName string) (types.ImagePullOptions, error) {
+func GetPullOptions(imageName string) (image.PullOptions, error) {
 	auth, err := EncodedAuth(imageName)
 	log.Debugf("Got image name: %s", imageName)
 	if err != nil {
-		return types.ImagePullOptions{}, err
+		return image.PullOptions{}, err
 	}
 
 	if auth == "" {
-		return types.ImagePullOptions{}, nil
+		return image.PullOptions{}, nil
 	}
 
 	// CREDENTIAL: Uncomment to log docker config auth
 	// log.Tracef("Got auth value: %s", auth)
 
-	return types.ImagePullOptions{
+	return image.PullOptions{
 		RegistryAuth:  auth,
 		PrivilegeFunc: DefaultAuthHandler,
 	}, nil
@@ -32,7 +34,7 @@ func GetPullOptions(imageName string) (types.ImagePullOptions, error) {
 // DefaultAuthHandler will be invoked if an AuthConfig is rejected
 // It could be used to return a new value for the "X-Registry-Auth" authentication header,
 // but there's no point trying again with the same value as used in AuthConfig
-func DefaultAuthHandler() (string, error) {
+func DefaultAuthHandler(ctx context.Context) (string, error) {
 	log.Debug("Authentication request was rejected. Trying again without authentication")
 	return "", nil
 }


### PR DESCRIPTION
## Summary
This PR fixes build errors caused by Docker SDK v28.5.2+ API reorganization. The Docker SDK moved many types from the main `types` package into more specific subpackages (`container`, `image`, etc.).

## Changes Made

### Type Updates
- **Image Operations**: `types.ImagePullOptions` → `image.PullOptions`
- **Container List**: `types.ContainerListOptions` → `container.ListOptions`
- **Container Operations**: Updated `ContainerRemoveOptions`, `ContainerStartOptions` to use `container` package
- **Exec Operations**: `types.ExecConfig` → `container.ExecOptions`, `types.ExecStartCheck` → `container.ExecStartOptions`
- **Image Removal**: `types.ImageRemoveOptions` → `image.RemoveOptions`
- **Image Delete Response**: `types.ImageDeleteResponseItem` → `image.DeleteResponse`

### API Signature Updates
- Updated `DefaultAuthHandler` to accept `context.Context` parameter (required by new `image.PullOptions.PrivilegeFunc` signature)

### Type Compatibility Fixes
- Fixed `ImageInspect.Config` type from `*container.Config` to `*dockerspec.DockerOCIImageConfig`
- Fixed `ExposedPorts` map indexing by converting `nat.Port` to `string` for compatibility

## Files Modified
- `pkg/registry/registry.go` - Image pull options and auth handler
- `pkg/container/client.go` - Container and image operations
- `pkg/container/container.go` - Port mapping compatibility
- `pkg/container/mocks/ApiServer.go` - Mock server for tests
- `pkg/container/client_test.go` - Test updates
- `pkg/container/container_mock_test.go` - Mock container updates

## Testing
- ✅ Build completes successfully
- ✅ Test files compile without errors
- ✅ All type conversions maintain backward compatibility

## Impact
This is a **non-breaking change** that updates internal type usage to match the Docker SDK v28 API structure while maintaining the same functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)