### PR TITLE
chore: add docker-compose files to dependabot monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,18 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 50
 
+  - package-ecosystem: "docker" # docker-compose.yml at root
+    directory: "/" # Location of docker-compose.yml
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 50
+
+  - package-ecosystem: "docker" # docker-compose.yml in container-networking
+    directory: "/dockerfiles/container-networking" # Location of docker-compose.yml
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 50
+
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
## Summary
- Adds Dependabot monitoring for two docker-compose.yml files that were previously not being tracked
- Adds entry for root `docker-compose.yml` (monitors prometheus, grafana, nginx images)
- Adds entry for `dockerfiles/container-networking/docker-compose.yml` (monitors gluetun, nginx)

## Background
The existing Dependabot configuration only monitored Dockerfiles in the `/dockerfiles` directory. Docker Compose files require separate entries with the "docker" package ecosystem pointing to their specific directories.

## What changed
Updated [.github/dependabot.yml](.github/dependabot.yml) to add two new docker package ecosystem entries:
1. Root directory (`/`) for docker-compose.yml
2. Container networking directory (`/dockerfiles/container-networking`) for its docker-compose.yml

## Test plan
- [ ] Verify Dependabot recognizes the new configuration
- [ ] Wait for Dependabot to create update PRs for outdated images in these compose files
- [ ] Confirm images like `prom/prometheus`, `grafana/grafana`, `qmcgaw/gluetun`, and `nginx` get update notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)