### PR TITLE
fix: use docker-compose ecosystem for compose files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,13 +23,13 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 50
 
-  - package-ecosystem: "docker" # docker-compose.yml at root
+  - package-ecosystem: "docker-compose" # docker-compose.yml at root
     directory: "/" # Location of docker-compose.yml
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 50
 
-  - package-ecosystem: "docker" # docker-compose.yml in container-networking
+  - package-ecosystem: "docker-compose" # docker-compose.yml in container-networking
     directory: "/dockerfiles/container-networking" # Location of docker-compose.yml
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary
- Updates Dependabot configuration to use the correct `docker-compose` package ecosystem for docker-compose.yml files
- Fixes invalid configuration error preventing Dependabot from detecting compose file dependencies

## Problem
PR #106 added entries for monitoring docker-compose.yml files, but used the `docker` ecosystem instead of the newly available `docker-compose` ecosystem. This caused Dependabot to show an invalid configuration error and fail to detect/monitor the compose files.

## Background
GitHub Dependabot released Docker Compose support in general availability on **February 25, 2025**. This requires using the dedicated `docker-compose` package ecosystem rather than the generic `docker` ecosystem.

## What Changed
Updated [.github/dependabot.yml](.github/dependabot.yml):
- Line 26: Changed `"docker"` → `"docker-compose"` for root docker-compose.yml
- Line 32: Changed `"docker"` → `"docker-compose"` for dockerfiles/container-networking/docker-compose.yml

The `docker` ecosystem should only be used for Dockerfiles (which is correctly configured at line 20).

## Test Plan
- [x] Verify YAML syntax is valid
- [ ] Wait for Dependabot to recognize the updated configuration
- [ ] Confirm Dependabot creates update PRs for outdated images in compose files:
  - `prom/prometheus` (root compose)
  - `grafana/grafana` (root compose)
  - `nginx` (root compose)
  - `qmcgaw/gluetun` (container-networking compose)
  - `nginx` (container-networking compose)

## References
- [Dependabot Docker Compose GA announcement (Feb 25, 2025)](https://github.blog/changelog/2025-02-25-dependabot-version-updates-now-support-docker-compose-in-general-availability/)
- [Dependabot configuration docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)

Fixes the invalid configuration issue reported for PR #106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)