### PR TITLE
fix: migrate release-dev workflow to modern docker actions

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -36,11 +36,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Publish to Docker Hub
-        uses: jerray/publish-docker-action@87d84711629b0dc9f6bb127b568413cc92a2088e #master@2022-10-14
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build and push to Docker Hub
+        uses: docker/build-push-action@v6
+        with:
+          context: .
           file: dockerfiles/Dockerfile.self-contained
-          repository: todd2982/watchtower
-          tags: latest-dev
+          push: true
+          tags: todd2982/watchtower:latest-dev


### PR DESCRIPTION
## Summary
- Replace deprecated jerray/publish-docker-action with modern Docker GitHub Actions
- Update release-dev workflow to use docker/build-push-action@v6
- Ensure CI/CD pipeline uses maintained actions with security updates

## Changes
- Added `docker/setup-buildx-action@v3` for enhanced build capabilities
- Added `docker/login-action@v3` for Docker Hub authentication  
- Replaced deprecated `jerray/publish-docker-action` (from 2022) with `docker/build-push-action@v6`
- Maintained same functionality: builds and pushes `latest-dev` tag on every push to main

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Workflow runs successfully on merge to main
- [ ] Docker image is built and pushed to Docker Hub as `todd2982/watchtower:latest-dev`
- [ ] Image is functional and can be pulled/run

## Related
Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)