### PR TITLE
fix: replace deprecated golang.org/x/net/context with standard library context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/net v0.48.0
 )
 
 require (
@@ -39,6 +38,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/net v0.48.0 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
 )
 

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types/network"
 	sdkClient "github.com/docker/docker/client"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 
 	"github.com/todd2982/watchtower/pkg/registry"
 	"github.com/todd2982/watchtower/pkg/registry/digest"


### PR DESCRIPTION
## Summary
- Replaced deprecated `golang.org/x/net/context` import with standard library `context` package in `pkg/container/client.go`
- Ran `go mod tidy` to clean up dependencies (moved `golang.org/x/net` to indirect dependencies)
- Build verified successfully

## Details
The `golang.org/x/net/context` package has been deprecated since Go 1.7 when the `context` package was added to the standard library. This change:
- Improves compatibility with modern Go tooling
- Removes dependency on outdated APIs that may be removed in future Go versions
- Follows Go best practices for current development

## Test Plan
- [x] Code builds successfully with `go build`
- [x] All imports updated correctly
- [x] Dependencies cleaned up with `go mod tidy`

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)