### PR TITLE
perf: add connection pooling for registry http requests

### DIFF
--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -21,6 +21,23 @@ import (
 // ContentDigestHeader is the key for the key-value pair containing the digest header
 const ContentDigestHeader = "Docker-Content-Digest"
 
+// httpClient is a shared HTTP client with connection pooling for registry requests
+var httpClient = &http.Client{
+	Transport: &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+	},
+}
+
 // CompareDigest ...
 func CompareDigest(container types.Container, registryAuth string) (bool, error) {
 	if !container.HasImageInfo() {
@@ -76,21 +93,6 @@ func TransformAuth(registryAuth string) string {
 
 // GetDigest from registry using a HEAD request to prevent rate limiting
 func GetDigest(url string, token string) (string, error) {
-	tr := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
-	}
-	client := &http.Client{Transport: tr}
-
 	req, _ := http.NewRequest("HEAD", url, nil)
 	req.Header.Set("User-Agent", meta.UserAgent)
 
@@ -109,7 +111,7 @@ func GetDigest(url string, token string) (string, error) {
 
 	logrus.WithField("url", url).Debug("Doing a HEAD request to fetch a digest")
 
-	res, err := client.Do(req)
+	res, err := httpClient.Do(req)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- Implements shared HTTP client with connection pooling for registry requests
- Replaces per-request client creation with package-level reusable client
- Reduces TCP connection overhead and improves registry operation performance

## Changes
- Created `httpClient` variable at package level with optimized transport configuration
- Removed redundant HTTP client and transport creation from `GetDigest` function
- Maintained all existing timeout and keepalive settings

## Impact
- **Performance:** Registry requests now reuse connections instead of creating new ones each time
- **Resource Efficiency:** Reduced file descriptor usage and TCP overhead
- **Backward Compatibility:** No API changes, fully backward compatible

## Test Plan
- [x] Code compiles successfully
- [x] No breaking changes to existing API
- [x] Connection pooling settings preserved from original implementation

Fixes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)